### PR TITLE
Promote Claude Code config to designed, tracked stow package

### DIFF
--- a/.stow-packages
+++ b/.stow-packages
@@ -1,5 +1,6 @@
 bash
 bin
+claude
 emacs
 git
 ssh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,16 @@ Discipline for any agent (human or otherwise) that touches this repo.
 
 - `brew bundle install` provisions macOS dependencies.
 - `stow $(cat .stow-packages)` deploys configurations. Idempotent.
+
+## Agent stack
+
+- Claude Code config: `claude/.claude/settings.json` (tracked,
+  designed). Permissions split into `allow` / `deny` / `ask` tiers;
+  personal overrides via untracked `~/.claude/settings.local.json`.
+- Claude Code slash commands: `claude/.claude/commands/*.md`. Each
+  command's `allowed-tools` frontmatter scopes its permissions
+  independently of the root settings; using the command IS the
+  authorization.
+- Per-directory scoped permissions: `<dir>/.claude/settings.local.json`
+  narrows the agent surface for work confined to that directory
+  (e.g., `scripts/.claude/settings.local.json` for the gh-API tools).

--- a/claude/.claude/commands/commit-push.md
+++ b/claude/.claude/commands/commit-push.md
@@ -1,0 +1,21 @@
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git push:*)
+description: Commit and push changes
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -10`
+
+## Your task
+
+Based on the above changes:
+
+1. Stage all relevant changes
+2. Create a single commit with an appropriate message
+3. Push the branch to origin
+
+You have the capability to call multiple tools in a single response. Stage, commit, and push using a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,0 +1,70 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "WebSearch",
+      "WebFetch",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(pwd:*)",
+      "Bash(cd:*)",
+      "Bash(which:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(echo:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(brew list:*)",
+      "Bash(brew info:*)"
+    ],
+    "deny": [
+      "Read(.env*)",
+      "Bash(rm -rf:*)"
+    ],
+    "ask": [
+      "Bash(git commit:*)",
+      "Bash(git push:*)"
+    ],
+    "defaultMode": "auto"
+  },
+  "effortLevel": "high",
+  "skipAutoPermissionPrompt": true,
+  "skipDangerousModePermissionPrompt": true,
+  "alwaysThinkingEnabled": true,
+  "enabledPlugins": {
+    "honcho@honcho": true,
+    "honcho-dev@honcho": true
+  },
+  "extraKnownMarketplaces": {
+    "honcho": {
+      "source": {
+        "source": "github",
+        "repo": "plastic-labs/claude-honcho"
+      }
+    }
+  },
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Engineering",
+      "Computing",
+      "Processing",
+      "Executing",
+      "Analyzing",
+      "Synthesizing",
+      "Calculating",
+      "Generating",
+      "Formulating",
+      "Determining",
+      "Deriving",
+      "Implementing"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Promote `~/.claude/settings.json` to a tracked file at `claude/.claude/settings.json` that is a **superset** of your existing personal config (Honcho plugin registration, custom `spinnerVerbs`, `alwaysThinkingEnabled`, `skipDangerousModePermissionPrompt`) **plus** a designed permission contract inspired by Mark Tran's: built-ins (Read/Glob/Grep/WebSearch/WebFetch), read-only shell (ls/find/cat/grep/pwd/cd/which/wc/head/tail/echo), git introspection (status/diff/log/branch), and macOS-specific read-only brew (list/info). Deny tier: `.env*` reads and `rm -rf`. Ask tier: `git commit` and `git push`. `effortLevel: high`, `defaultMode: auto`.
- Add `/commit-push` slash command (`claude/.claude/commands/commit-push.md`) ported verbatim from Mark. The frontmatter `allowed-tools` scopes git add/status/commit/push to this command only, overriding the root `ask` tier — using the command IS the explicit authorization.
- Register `claude` in `.stow-packages` so the bootstrap recipe deploys it.
- Extend `AGENTS.md` with an Agent stack section documenting the Claude Code conventions (settings layering, slash command frontmatter scoping, per-directory scoped permissions).

## What's preserved

Every key in your existing `~/.claude/settings.json` is preserved byte-for-byte in the new tracked file (verified pre-commit via JSON deep-equal). Honcho memory layer keeps working untouched.

## What's deferred to later PRs

The AGENTS.md section is intentionally narrow — Pi harness and harness-agnostic skills directories arrive in separate PRs alongside their Stow packages.

## Test plan

- [x] All three commits signed (`G j.taylor.hodge@gmail.com`, ED25519).
- [x] Byte-identity vs source branch: `git diff --quiet feat/claude-stack jthodge/claude-stack` exits 0.
- [x] Existing settings.json keys preserved: `python3` deep-equal check vs `~/.claude/settings.json` shows 0 missing keys and 0 changed values.
- [x] Pre-commit hook ran clean on every commit (no secret patterns triggered).
- [x] After merge: `rm ~/.claude/settings.json && stow -d ~/tilde -t ~ claude` to materialize the symlink. Confirm Claude Code starts up reading the new merged config (Honcho still loads, custom spinner verbs still appear).
- [x] After deploy: `/commit-push` slash command is discoverable in a Claude Code session.