### PR TITLE
Ship harness-agnostic skill library

### DIFF
--- a/.stow-packages
+++ b/.stow-packages
@@ -1,3 +1,4 @@
+agents
 bash
 bin
 claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,12 @@ Discipline for any agent (human or otherwise) that touches this repo.
 - Per-directory scoped permissions: `<dir>/.claude/settings.local.json`
   narrows the agent surface for work confined to that directory
   (e.g., `scripts/.claude/settings.local.json` for the gh-API tools).
+- Pi harness: `pi/.pi/agent/`. Subagents (scout/planner/worker/
+  reviewer) decompose work by model tier; presets (`plan`, `implement`)
+  toggle model + tool surface; extensions live in
+  `pi/.pi/agent/extensions/`. Authenticated via OAuth subscriptions
+  (`pi /login`), not API keys. See README for install path.
+- Harness-agnostic skill library: `agents/.agents/skills/<name>/SKILL.md`.
+  Any harness following the SKILL.md convention (Pi via its skills
+  loader, Claude Code via plugins) can consume them. Skills are
+  reusable across tool churn — they outlive any single harness.

--- a/agents/.agents/skills/defuddle/SKILL.md
+++ b/agents/.agents/skills/defuddle/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: defuddle
+description: Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, so fetch those directly.
+---
+
+# Defuddle
+
+Use Defuddle CLI to extract clean readable content from web pages. Prefer it over generic page fetching for standard web pages — it removes navigation, ads, and clutter, reducing token usage.
+
+If not installed: `npm install -g defuddle`
+
+## Usage
+
+Always use `--md` for markdown output:
+
+```bash
+defuddle parse <url> --md
+```
+
+Save to file:
+
+```bash
+defuddle parse <url> --md -o content.md
+```
+
+Extract specific metadata:
+
+```bash
+defuddle parse <url> -p title
+defuddle parse <url> -p description
+defuddle parse <url> -p domain
+```
+
+## Output formats
+
+| Flag | Format |
+|------|--------|
+| `--md` | Markdown (default choice) |
+| `--json` | JSON with both HTML and markdown |
+| (none) | HTML |
+| `-p <name>` | Specific metadata property |

--- a/agents/.agents/skills/json-canvas/SKILL.md
+++ b/agents/.agents/skills/json-canvas/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: json-canvas
+description: Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas files, creating visual canvases, mind maps, flowcharts, or when the user mentions Canvas files in Obsidian.
+---
+
+# JSON Canvas Skill
+
+## File Structure
+
+A canvas file (`.canvas`) contains two top-level arrays following the [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/):
+
+```json
+{
+  "nodes": [],
+  "edges": []
+}
+```
+
+- `nodes` (optional): Array of node objects
+- `edges` (optional): Array of edge objects connecting nodes
+
+## Common Workflows
+
+### 1. Create a New Canvas
+
+1. Create a `.canvas` file with the base structure `{"nodes": [], "edges": []}`
+2. Generate unique 16-character hex IDs for each node (e.g., `"6f0ad84f44ce9c17"`)
+3. Add nodes with required fields: `id`, `type`, `x`, `y`, `width`, `height`
+4. Add edges referencing valid node IDs via `fromNode` and `toNode`
+5. **Validate**: Parse the JSON to confirm it is valid. Verify all `fromNode`/`toNode` values exist in the nodes array
+
+### 2. Add a Node to an Existing Canvas
+
+1. Read and parse the existing `.canvas` file
+2. Generate a unique ID that does not collide with existing node or edge IDs
+3. Choose position (`x`, `y`) that avoids overlapping existing nodes (leave 50-100px spacing)
+4. Append the new node object to the `nodes` array
+5. Optionally add edges connecting the new node to existing nodes
+6. **Validate**: Confirm all IDs are unique and all edge references resolve to existing nodes
+
+### 3. Connect Two Nodes
+
+1. Identify the source and target node IDs
+2. Generate a unique edge ID
+3. Set `fromNode` and `toNode` to the source and target IDs
+4. Optionally set `fromSide`/`toSide` (top, right, bottom, left) for anchor points
+5. Optionally set `label` for descriptive text on the edge
+6. Append the edge to the `edges` array
+7. **Validate**: Confirm both `fromNode` and `toNode` reference existing node IDs
+
+### 4. Edit an Existing Canvas
+
+1. Read and parse the `.canvas` file as JSON
+2. Locate the target node or edge by `id`
+3. Modify the desired attributes (text, position, color, etc.)
+4. Write the updated JSON back to the file
+5. **Validate**: Re-check all ID uniqueness and edge reference integrity after editing
+
+## Nodes
+
+Nodes are objects placed on the canvas. Array order determines z-index: first node = bottom layer, last node = top layer.
+
+### Generic Node Attributes
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `id` | Yes | string | Unique 16-char hex identifier |
+| `type` | Yes | string | `text`, `file`, `link`, or `group` |
+| `x` | Yes | integer | X position in pixels |
+| `y` | Yes | integer | Y position in pixels |
+| `width` | Yes | integer | Width in pixels |
+| `height` | Yes | integer | Height in pixels |
+| `color` | No | canvasColor | Preset `"1"`-`"6"` or hex (e.g., `"#FF0000"`) |
+
+### Text Nodes
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `text` | Yes | string | Plain text with Markdown syntax |
+
+```json
+{
+  "id": "6f0ad84f44ce9c17",
+  "type": "text",
+  "x": 0,
+  "y": 0,
+  "width": 400,
+  "height": 200,
+  "text": "# Hello World\n\nThis is **Markdown** content."
+}
+```
+
+**Newline pitfall**: Use `\n` for line breaks in JSON strings. Do **not** use the literal `\\n` -- Obsidian renders that as the characters `\` and `n`.
+
+### File Nodes
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `file` | Yes | string | Path to file within the system |
+| `subpath` | No | string | Link to heading or block (starts with `#`) |
+
+```json
+{
+  "id": "a1b2c3d4e5f67890",
+  "type": "file",
+  "x": 500,
+  "y": 0,
+  "width": 400,
+  "height": 300,
+  "file": "Attachments/diagram.png"
+}
+```
+
+### Link Nodes
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `url` | Yes | string | External URL |
+
+```json
+{
+  "id": "c3d4e5f678901234",
+  "type": "link",
+  "x": 1000,
+  "y": 0,
+  "width": 400,
+  "height": 200,
+  "url": "https://obsidian.md"
+}
+```
+
+### Group Nodes
+
+Groups are visual containers for organizing other nodes. Position child nodes inside the group's bounds.
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `label` | No | string | Text label for the group |
+| `background` | No | string | Path to background image |
+| `backgroundStyle` | No | string | `cover`, `ratio`, or `repeat` |
+
+```json
+{
+  "id": "d4e5f6789012345a",
+  "type": "group",
+  "x": -50,
+  "y": -50,
+  "width": 1000,
+  "height": 600,
+  "label": "Project Overview",
+  "color": "4"
+}
+```
+
+## Edges
+
+Edges connect nodes via `fromNode` and `toNode` IDs.
+
+| Attribute | Required | Type | Default | Description |
+|-----------|----------|------|---------|-------------|
+| `id` | Yes | string | - | Unique identifier |
+| `fromNode` | Yes | string | - | Source node ID |
+| `fromSide` | No | string | - | `top`, `right`, `bottom`, or `left` |
+| `fromEnd` | No | string | `none` | `none` or `arrow` |
+| `toNode` | Yes | string | - | Target node ID |
+| `toSide` | No | string | - | `top`, `right`, `bottom`, or `left` |
+| `toEnd` | No | string | `arrow` | `none` or `arrow` |
+| `color` | No | canvasColor | - | Line color |
+| `label` | No | string | - | Text label |
+
+```json
+{
+  "id": "0123456789abcdef",
+  "fromNode": "6f0ad84f44ce9c17",
+  "fromSide": "right",
+  "toNode": "a1b2c3d4e5f67890",
+  "toSide": "left",
+  "toEnd": "arrow",
+  "label": "leads to"
+}
+```
+
+## Colors
+
+The `canvasColor` type accepts either a hex string or a preset number:
+
+| Preset | Color |
+|--------|-------|
+| `"1"` | Red |
+| `"2"` | Orange |
+| `"3"` | Yellow |
+| `"4"` | Green |
+| `"5"` | Cyan |
+| `"6"` | Purple |
+
+Preset color values are intentionally undefined -- applications use their own brand colors.
+
+## ID Generation
+
+Generate 16-character lowercase hexadecimal strings (64-bit random value):
+
+```
+"6f0ad84f44ce9c17"
+"a3b2c1d0e9f8a7b6"
+```
+
+## Layout Guidelines
+
+- Coordinates can be negative (canvas extends infinitely)
+- `x` increases right, `y` increases down; position is the top-left corner
+- Space nodes 50-100px apart; leave 20-50px padding inside groups
+- Align to grid (multiples of 10 or 20) for cleaner layouts
+
+| Node Type | Suggested Width | Suggested Height |
+|-----------|-----------------|------------------|
+| Small text | 200-300 | 80-150 |
+| Medium text | 300-450 | 150-300 |
+| Large text | 400-600 | 300-500 |
+| File preview | 300-500 | 200-400 |
+| Link preview | 250-400 | 100-200 |
+
+## Validation Checklist
+
+After creating or editing a canvas file, verify:
+
+1. All `id` values are unique across both nodes and edges
+2. Every `fromNode` and `toNode` references an existing node ID
+3. Required fields are present for each node type (`text` for text nodes, `file` for file nodes, `url` for link nodes)
+4. `type` is one of: `text`, `file`, `link`, `group`
+5. `fromSide`/`toSide` values are one of: `top`, `right`, `bottom`, `left`
+6. `fromEnd`/`toEnd` values are one of: `none`, `arrow`
+7. Color presets are `"1"` through `"6"` or valid hex (e.g., `"#FF0000"`)
+8. JSON is valid and parseable
+
+If validation fails, check for duplicate IDs, dangling edge references, or malformed JSON strings (especially unescaped newlines in text content).
+
+## Complete Examples
+
+See [references/EXAMPLES.md](references/EXAMPLES.md) for full canvas examples including mind maps, project boards, research canvases, and flowcharts.
+
+## References
+
+- [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/)
+- [JSON Canvas GitHub](https://github.com/obsidianmd/jsoncanvas)

--- a/agents/.agents/skills/json-canvas/references/EXAMPLES.md
+++ b/agents/.agents/skills/json-canvas/references/EXAMPLES.md
@@ -1,0 +1,329 @@
+# JSON Canvas Complete Examples
+
+## Simple Canvas with Text and Connections
+
+```json
+{
+  "nodes": [
+    {
+      "id": "8a9b0c1d2e3f4a5b",
+      "type": "text",
+      "x": 0,
+      "y": 0,
+      "width": 300,
+      "height": 150,
+      "text": "# Main Idea\n\nThis is the central concept."
+    },
+    {
+      "id": "1a2b3c4d5e6f7a8b",
+      "type": "text",
+      "x": 400,
+      "y": -100,
+      "width": 250,
+      "height": 100,
+      "text": "## Supporting Point A\n\nDetails here."
+    },
+    {
+      "id": "2b3c4d5e6f7a8b9c",
+      "type": "text",
+      "x": 400,
+      "y": 100,
+      "width": 250,
+      "height": 100,
+      "text": "## Supporting Point B\n\nMore details."
+    }
+  ],
+  "edges": [
+    {
+      "id": "3c4d5e6f7a8b9c0d",
+      "fromNode": "8a9b0c1d2e3f4a5b",
+      "fromSide": "right",
+      "toNode": "1a2b3c4d5e6f7a8b",
+      "toSide": "left"
+    },
+    {
+      "id": "4d5e6f7a8b9c0d1e",
+      "fromNode": "8a9b0c1d2e3f4a5b",
+      "fromSide": "right",
+      "toNode": "2b3c4d5e6f7a8b9c",
+      "toSide": "left"
+    }
+  ]
+}
+```
+
+## Project Board with Groups
+
+```json
+{
+  "nodes": [
+    {
+      "id": "5e6f7a8b9c0d1e2f",
+      "type": "group",
+      "x": 0,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "To Do",
+      "color": "1"
+    },
+    {
+      "id": "6f7a8b9c0d1e2f3a",
+      "type": "group",
+      "x": 350,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "In Progress",
+      "color": "3"
+    },
+    {
+      "id": "7a8b9c0d1e2f3a4b",
+      "type": "group",
+      "x": 700,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "Done",
+      "color": "4"
+    },
+    {
+      "id": "8b9c0d1e2f3a4b5c",
+      "type": "text",
+      "x": 20,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 1\n\nImplement feature X"
+    },
+    {
+      "id": "9c0d1e2f3a4b5c6d",
+      "type": "text",
+      "x": 370,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 2\n\nReview PR #123",
+      "color": "2"
+    },
+    {
+      "id": "0d1e2f3a4b5c6d7e",
+      "type": "text",
+      "x": 720,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 3\n\n~~Setup CI/CD~~"
+    }
+  ],
+  "edges": []
+}
+```
+
+## Research Canvas with Files and Links
+
+```json
+{
+  "nodes": [
+    {
+      "id": "1e2f3a4b5c6d7e8f",
+      "type": "text",
+      "x": 300,
+      "y": 200,
+      "width": 400,
+      "height": 200,
+      "text": "# Research Topic\n\n## Key Questions\n\n- How does X affect Y?\n- What are the implications?",
+      "color": "5"
+    },
+    {
+      "id": "2f3a4b5c6d7e8f9a",
+      "type": "file",
+      "x": 0,
+      "y": 0,
+      "width": 250,
+      "height": 150,
+      "file": "Literature/Paper A.pdf"
+    },
+    {
+      "id": "3a4b5c6d7e8f9a0b",
+      "type": "file",
+      "x": 0,
+      "y": 200,
+      "width": 250,
+      "height": 150,
+      "file": "Notes/Meeting Notes.md",
+      "subpath": "#Key Insights"
+    },
+    {
+      "id": "4b5c6d7e8f9a0b1c",
+      "type": "link",
+      "x": 0,
+      "y": 400,
+      "width": 250,
+      "height": 100,
+      "url": "https://example.com/research"
+    },
+    {
+      "id": "5c6d7e8f9a0b1c2d",
+      "type": "file",
+      "x": 750,
+      "y": 150,
+      "width": 300,
+      "height": 250,
+      "file": "Attachments/diagram.png"
+    }
+  ],
+  "edges": [
+    {
+      "id": "6d7e8f9a0b1c2d3e",
+      "fromNode": "2f3a4b5c6d7e8f9a",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "label": "supports"
+    },
+    {
+      "id": "7e8f9a0b1c2d3e4f",
+      "fromNode": "3a4b5c6d7e8f9a0b",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "label": "informs"
+    },
+    {
+      "id": "8f9a0b1c2d3e4f5a",
+      "fromNode": "4b5c6d7e8f9a0b1c",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "toEnd": "arrow",
+      "color": "6"
+    },
+    {
+      "id": "9a0b1c2d3e4f5a6b",
+      "fromNode": "1e2f3a4b5c6d7e8f",
+      "fromSide": "right",
+      "toNode": "5c6d7e8f9a0b1c2d",
+      "toSide": "left",
+      "label": "visualized by"
+    }
+  ]
+}
+```
+
+## Flowchart
+
+```json
+{
+  "nodes": [
+    {
+      "id": "a0b1c2d3e4f5a6b7",
+      "type": "text",
+      "x": 200,
+      "y": 0,
+      "width": 150,
+      "height": 60,
+      "text": "**Start**",
+      "color": "4"
+    },
+    {
+      "id": "b1c2d3e4f5a6b7c8",
+      "type": "text",
+      "x": 200,
+      "y": 100,
+      "width": 150,
+      "height": 60,
+      "text": "Step 1:\nGather data"
+    },
+    {
+      "id": "c2d3e4f5a6b7c8d9",
+      "type": "text",
+      "x": 200,
+      "y": 200,
+      "width": 150,
+      "height": 80,
+      "text": "**Decision**\n\nIs data valid?",
+      "color": "3"
+    },
+    {
+      "id": "d3e4f5a6b7c8d9e0",
+      "type": "text",
+      "x": 400,
+      "y": 200,
+      "width": 150,
+      "height": 60,
+      "text": "Process data"
+    },
+    {
+      "id": "e4f5a6b7c8d9e0f1",
+      "type": "text",
+      "x": 0,
+      "y": 200,
+      "width": 150,
+      "height": 60,
+      "text": "Request new data",
+      "color": "1"
+    },
+    {
+      "id": "f5a6b7c8d9e0f1a2",
+      "type": "text",
+      "x": 400,
+      "y": 320,
+      "width": 150,
+      "height": 60,
+      "text": "**End**",
+      "color": "4"
+    }
+  ],
+  "edges": [
+    {
+      "id": "a6b7c8d9e0f1a2b3",
+      "fromNode": "a0b1c2d3e4f5a6b7",
+      "fromSide": "bottom",
+      "toNode": "b1c2d3e4f5a6b7c8",
+      "toSide": "top"
+    },
+    {
+      "id": "b7c8d9e0f1a2b3c4",
+      "fromNode": "b1c2d3e4f5a6b7c8",
+      "fromSide": "bottom",
+      "toNode": "c2d3e4f5a6b7c8d9",
+      "toSide": "top"
+    },
+    {
+      "id": "c8d9e0f1a2b3c4d5",
+      "fromNode": "c2d3e4f5a6b7c8d9",
+      "fromSide": "right",
+      "toNode": "d3e4f5a6b7c8d9e0",
+      "toSide": "left",
+      "label": "Yes",
+      "color": "4"
+    },
+    {
+      "id": "d9e0f1a2b3c4d5e6",
+      "fromNode": "c2d3e4f5a6b7c8d9",
+      "fromSide": "left",
+      "toNode": "e4f5a6b7c8d9e0f1",
+      "toSide": "right",
+      "label": "No",
+      "color": "1"
+    },
+    {
+      "id": "e0f1a2b3c4d5e6f7",
+      "fromNode": "e4f5a6b7c8d9e0f1",
+      "fromSide": "top",
+      "fromEnd": "none",
+      "toNode": "b1c2d3e4f5a6b7c8",
+      "toSide": "left",
+      "toEnd": "arrow"
+    },
+    {
+      "id": "f1a2b3c4d5e6f7a8",
+      "fromNode": "d3e4f5a6b7c8d9e0",
+      "fromSide": "bottom",
+      "toNode": "f5a6b7c8d9e0f1a2",
+      "toSide": "top"
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

- Create the `agents/` stow package (targets `~/.agents/skills/`) — a harness-agnostic skill library consumable by any tool that follows the SKILL.md convention.
- **defuddle** (web content extraction via the Defuddle CLI, removes nav/ads/clutter to save tokens) and **json-canvas** (JSON Canvas spec for `.canvas` files — node-graph format harness-agnostic at the JSON layer).
- Extend `AGENTS.md` with Pi harness and skill library bullets, closing the Agent stack documentation for this migration.
- Register `agents` in `.stow-packages` (first alphabetically).

## Test plan

- [x] All three commits signed (`G j.taylor.hodge@gmail.com`, ED25519 SHA256:hjvlFnFJwVXqRRnnsHww/vFi1yjQ1CFyOlRDLo0e074).
- [x] Byte-identity vs source branch: `git diff --quiet feat/agent-skills jthodge/agent-skills` exits 0.
- [x] defuddle and json-canvas
- [x] Pre-commit hook ran clean on every commit.
- [x] After merge: `stow -d ~/tilde -t ~ agents` to symlink `~/.agents/skills/` to the tracked tree. Confirm Pi's skill loader discovers the new skills.
- [ ] Optional: `npm install -g defuddle` if you want the defuddle skill operational immediately. Skill content documents its own install.

## Phase complete

This is the final PR of the Scope Y migration. After merge:

- Claude Code formalized (PR #7, merged)
- Pi harness fully ported (PR #8, merged)
- Harness-agnostic skill library (this PR)