### PR TITLE
Enable option_as_alt in Alacritty for vim-tmux-navigator chord

### DIFF
--- a/alacritty/.config/alacritty/alacritty.toml
+++ b/alacritty/.config/alacritty/alacritty.toml
@@ -14,6 +14,7 @@ padding.y = 3
 dynamic_padding = true
 decorations = "None"
 opacity = 1.0
+option_as_alt = "Both"
 
 [keyboard]
 bindings = [


### PR DESCRIPTION
## Summary

One-line fix to close the Alacritty/Ghostty parity gap on the M-h/j/k/l vim-tmux-navigator chord (introduced in PR #11).

macOS Alacritty defaults the Option key to emit Unicode characters (©, é, ™, etc. — macOS convention). Ghostty inverts this. Result: in Alacritty, Option+J inserts ∆ instead of reaching tmux's keymap, so split-boundary motion fails.

Add `option_as_alt = "Both"` under `[window]` in `alacritty/.config/alacritty/alacritty.toml` so both Option keys send Alt unconditionally.

## Trade-off

macOS-native Option+character Unicode shortcuts no longer work inside Alacritty. They still work everywhere else on the system; this only affects keypresses inside the Alacritty window. If you want to keep one Option key for Unicode, use `"OnlyLeft"` or `"OnlyRight"` instead — easy follow-up edit.

## Test plan

- [x] Commit signed (`G j.taylor.hodge@gmail.com`, ED25519).
- [x] Byte-identity vs source branch: `git diff --quiet fix/alacritty-option-as-alt jthodge/alacritty-meta` exits 0.
- [x] Pre-commit hook ran clean.
- [ ] After merge + `stow -R alacritty`: relaunch Alacritty (Cmd+Q + reopen to pick up the new config), run tmux with nvim split inside, confirm M-j crosses the nvim/tmux pane boundary cleanly.
- [ ] Same chord still works in Ghostty (regression check; should be unaffected).

## Reference

[Alacritty docs on `option_as_alt`](https://alacritty.org/config-alacritty.html#window) — values: `OnlyLeft`, `OnlyRight`, `Both`, `None` (default).