### PR TITLE
chore: codify .context/ cross-agent coordination convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # tmux runtime plugin state (tpm installs into here; tpm itself is a tracked submodule)
 tmux/.tmux/plugins/*
+
+# Cross-agent coordination scratch (per-directory, ephemeral)
+.context/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,8 @@ visual state is identical across them.
   Any harness following the SKILL.md convention (Pi via its skills
   loader, Claude Code via plugins) can consume them. Skills are
   reusable across tool churn — they outlive any single harness.
+- Cross-agent coordination scratch: per-directory `.context/`
+  directories (gitignored repo-wide) hold ephemeral plans, notes,
+  and intermediate output shared between agent invocations. Not
+  for committed documentation — for short-lived runtime state
+  that humans rarely review but agents need to hand off.


### PR DESCRIPTION
## Summary

Documents the `.context/` per-directory convention so it's discoverable from tracked files instead of only living in personal profile memory.

- `.gitignore` gains a `.context/` entry (directory-only, matches at any depth)
- `AGENTS.md` gains a bullet under the Agent stack section describing purpose (ephemeral plans, notes, intermediate output handed between agent invocations) and boundary (not for committed docs — for short-lived runtime state)

Net change: +8 lines across 2 files. No tracked content moves; no agent behavior changes today.

## Verification

- \`git diff jthodge/context-convention..chore/context-convention\` — empty (byte-identity preserved through cherry-pick -S)
- Pre-commit secret scanner: passed
- Commit signed via op-ssh-sign

## Test plan

- [x] \`.gitignore\` correctly ignores a new `foo/.context/scratch.md` (directory-only, depth-agnostic match)
- [x] AGENTS.md renders the new bullet at the end of the Agent stack section