### PR TITLE
chore: drift-proof README stow-package paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ brew bundle install
 stow -d . -t "$HOME" $(cat .stow-packages)
 ```
 
-Each entry in `.stow-packages` (`bash`, `bin`, `emacs`, `git`, `zsh`)
-mirrors a slice of `$HOME`. The `scripts/` directory is intentionally
-not stowed — its contents are invoked in place.
+Each entry in `.stow-packages` mirrors a slice of `$HOME`; the
+file is the canonical list and the bootstrap above feeds it to
+`stow` verbatim. The `scripts/` directory is intentionally not
+stowed — its contents are invoked in place.
 
 ## GitHub SSH key registration
 


### PR DESCRIPTION
## Summary

The Bootstrap section's stow paragraph hard-coded the package list as \`bash, bin, emacs, git, zsh\` — a five-entry snapshot frozen in time. The repo has since grown to 13 packages across the migration. Naming packages inline guarantees the paragraph drifts again on the next addition.

Rewrite the paragraph to point at \`.stow-packages\` as the canonical list rather than restating its contents. The bootstrap command one line above already feeds \`\$(cat .stow-packages)\` straight to \`stow\`, so the paragraph now matches reality and won't drift on the next package addition.

Net change: -3 / +4 lines, README only.

## Verification

- \`git diff jthodge/readme-stow-list..chore/readme-stow-list\` — empty (byte-identity preserved)
- Pre-commit secret scanner: passed
- Commit signed via op-ssh-sign

## Test plan

- [x] README renders with no inline package list
- [x] Bootstrap command and paragraph now agree about `.stow-packages` being the source of truth