### PR TITLE
chore: prune dead lines from zshrc

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -36,7 +36,6 @@ eval "$(zoxide init zsh)"
 
 ### Compiler
 alias gcc=/opt/homebrew/bin/gcc-14
-# alias gcc=/usr/bin/gcc
 
 ## Haskell
 
@@ -93,7 +92,6 @@ fi
 
 ## Claude
 alias claude="/Users/jth/.claude/local/claude"
-
 
 export GOPATH="$HOME/go"; export GOROOT="$HOME/.go"; export PATH="$GOPATH/bin:$PATH"; # g-install: do NOT edit, see https://github.com/stefanmaric/g
 


### PR DESCRIPTION
## Summary

Two surgical removals:

1. The commented-out \`# alias gcc=/usr/bin/gcc\` directly below the active \`alias gcc=/opt/homebrew/bin/gcc-14\` — stale fallback from before Homebrew gcc-14 was the default. Keeping a commented alternative next to the live one invites confusion about whether it's a toggle, a TODO, or load-bearing.
2. The double blank line between the \`claude\` alias and the \`GOPATH\` g-install export — the rest of the file uses single blanks between sub-blocks.

Pure cosmetic. Net -2 lines, behavior identical. The \`op read\` HONCHO injection at the bottom is deliberately untouched.

## Verification

- \`git diff jthodge/zshrc-hygiene..chore/zshrc-hygiene\` — empty (byte-identity preserved)
- Diff safety scan: no \`hch-v3-\` or \`HONCHO_API_KEY="hch\` patterns introduced
- Pre-commit secret scanner: passed
- Commit signed via op-ssh-sign

## Test plan

- [x] \`source ~/.zshrc\` in a fresh shell — no errors, no behavior change
- [x] \`alias gcc\` resolves to \`/opt/homebrew/bin/gcc-14\`
- [x] \`echo \$HONCHO_API_KEY\` still pulls from 1Password