### PR TITLE
fix(shell): make fish take over Alacritty after chsh

### DIFF
--- a/alacritty/.config/alacritty/alacritty.toml
+++ b/alacritty/.config/alacritty/alacritty.toml
@@ -24,5 +24,5 @@ bindings = [
 ]
 
 [terminal.shell]
-program = "/bin/zsh"
+program = "/opt/homebrew/bin/fish"
 args = ["-l"]

--- a/fish/.config/fish/exports.fish
+++ b/fish/.config/fish/exports.fish
@@ -1,5 +1,12 @@
 # Identity
 
+## SHELL
+## Alacritty execs fish directly (no /usr/bin/login wrapper), so $SHELL
+## leaks from launchd's session env. Self-correct here so downstream
+## tools (git's editor chooser, completion emitters keying off $SHELL,
+## tmux's default-shell inheritance) see the truth.
+set -gx SHELL (command -v fish)
+
 ## 1Password SSH agent
 set -gx SSH_AUTH_SOCK "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 


### PR DESCRIPTION
## Summary

Post-merge follow-ups to PR #19. After `chsh -s /opt/homebrew/bin/fish`,
two layers between the OS-recorded login shell and the actual running
shell kept Alacritty in zsh:

1. **Alacritty's `[terminal.shell].program` pin** still pointed at
   `/bin/zsh` from the pre-migration config.
2. **macOS launchd's session env caches `$SHELL`** from before `chsh`,
   so even with the pin removed, `$SHELL` leaked `/bin/zsh` into fish.

This PR closes both gaps so a fresh Alacritty window actually
launches fish, and tools that key off `$SHELL` (git's editor chooser,
`ngrok completion`, tmux's `default-shell` inheritance) see the truth.

## Commits

- `chore(alacritty): pin terminal.shell to fish` — keeps the
  explicit pin (insulates from launchd's `$SHELL` cache) but flips
  it to fish.
- `feat(fish): self-correct $SHELL on startup` — fish exports
  `SHELL=(command -v fish)` in `exports.fish`, resolving to the
  brew symlink (`/opt/homebrew/bin/fish`) which matches `/etc/shells`.

## Test plan

- [ ] `killall alacritty` and relaunch from Finder/Raycast
- [ ] In the fresh window: `echo $SHELL` reports `/opt/homebrew/bin/fish`
- [ ] `grep -q "^$SHELL\$" /etc/shells; and echo OK` prints `OK`
- [ ] Tide prompt renders (Spaceship is gone)
- [ ] `git commit` (in a test repo) launches `$EDITOR` cleanly